### PR TITLE
Upgrade codecov-action

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -74,7 +74,7 @@ jobs:
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
 
@@ -129,7 +129,7 @@ jobs:
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
 
@@ -209,6 +209,6 @@ jobs:
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
##### SUMMARY

Upgrade `codecov/codecov-action` to v2.
Version 1 is [deprecated and will be fully sunset and no longer function as of February 1, 2022.](https://github.com/codecov/codecov-action/tree/b049ab51f46ef6cd9c7ca52a856631a818969c7c#%EF%B8%8F--deprecration-of-v1)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test workflow

##### ADDITIONAL INFORMATION

n/a
