### PR TITLE
Integrate `stable-2.13` in GHA

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,16 +37,12 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          # An alternative to `devel` is the `milestone` branch with
-          # gets synchronized with `devel` every few weeks and therefore
-          # is a more stable target.
         # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12
           - stable-2.13
-        # - devel # Only if you prefer bleeding-edge instability
-          - milestone
+          - devel
     runs-on: ubuntu-latest
     steps:
       # Run sanity tests inside a Docker container.
@@ -81,8 +77,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
-        # - devel # Only if you prefer bleeding-edge instability
-          - milestone
+          - devel
 
     steps:
       - name: >-
@@ -120,8 +115,7 @@ jobs:
           - stable-2.11
           - stable-2.12
           - stable-2.13
-        # - devel # Only if you prefer bleeding-edge instability
-          - milestone
+          - devel
         python:
           - '2.6'
           - '2.7'

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,11 +37,16 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
+          # An alternative to `devel` is the `milestone` branch with
+          # gets synchronized with `devel` every few weeks and therefore
+          # is a more stable target.
         # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          - devel
+          - stable-2.13
+        # - devel # Only if you prefer bleeding-edge instability
+          - milestone
     runs-on: ubuntu-latest
     steps:
       # Run sanity tests inside a Docker container.
@@ -75,7 +80,9 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          - devel
+          - stable-2.13
+        # - devel # Only if you prefer bleeding-edge instability
+          - milestone
 
     steps:
       - name: >-
@@ -112,7 +119,9 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          - devel
+          - stable-2.13
+        # - devel # Only if you prefer bleeding-edge instability
+          - milestone
         python:
           - '2.6'
           - '2.7'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch adds ansible-core 2.13 to the default matrix and offers better _default_ stability when testing against the next unreleased ansible-core version.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GHA

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This supersedes an incomplete PR https://github.com/ansible-collections/collection_template/pull/45.
Resolves #45.