### PR TITLE
Enable auto-cancellation of outdated CI runs

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -23,6 +23,13 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
+
 jobs:
 
 ###


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows to use less CI resources by cancelling old in-progress GHA runs when new commits get pushed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GHA

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A