### PR TITLE
Create initial empty test dirs

### DIFF
--- a/tests/integration/targets/.gitkeep
+++ b/tests/integration/targets/.gitkeep
@@ -1,0 +1,3 @@
+This is a placeholder file that only exists to keep the current
+directory in Git. It is safe to remove it once this directory contains
+the actual test files.

--- a/tests/units/.gitkeep
+++ b/tests/units/.gitkeep
@@ -1,0 +1,3 @@
+This is a placeholder file that only exists to keep the current
+directory in Git. It is safe to remove it once this directory contains
+the actual test files.


### PR DESCRIPTION
This is necessary so that after creating a new project from this repository template, the GHA CI/CD wouldn't fail immediately.
