### PR TITLE
CI: the milestone branch has been updated, use ubuntu-latest for it

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -70,7 +70,7 @@ jobs:
     # for the latest list.
     runs-on: >-
       ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11", "milestone"]'
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
       # Run sanity tests inside a Docker container.
@@ -100,7 +100,7 @@ jobs:
     # for the latest list.
     runs-on: >-
       ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11", "milestone"]'
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
@@ -149,7 +149,7 @@ jobs:
     # for the latest list.
     runs-on: >-
       ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11", "milestone"]'
+          '["stable-2.9", "stable-2.10", "stable-2.11"]'
       ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:


### PR DESCRIPTION
##### SUMMARY
The `milestone` branch has been updated (https://github.com/ansible-collections/news-for-maintainers/issues/30), so there's no more need to fall back to `ubuntu-20.04` for that one.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
