### PR TITLE
Exclude Python 2.6 from running with unsupported Ansible versions

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -202,6 +202,13 @@ jobs:
             python: '3.10'
           - ansible: stable-2.11
             python: '3.10'
+          # Python 2.6 is not supported with ansible-core >= 2.13
+          - ansible: stable-2.13
+            python: '2.6'
+          - ansible: stable-2.14
+            python: '2.6'
+          - ansible: devel
+            python: '2.6'
             
 
     steps:


### PR DESCRIPTION
##### SUMMARY

Exclude Python 2.6 from running with ansible-core >= 2.13 in the integration job matrix.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GitHub Actions


