### PR TITLE
Remove spaces from `requires_ansible`

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>= 2.11.0'  # Use '>= 2.9.10' instead, if needed
+requires_ansible: '>=2.11.0'  # Use '>=2.9.10' instead, if needed


### PR DESCRIPTION
##### SUMMARY
`ansible-galaxy collection publish` fails because `requires_ansible` contains a space:

```
'requires_ansible' is not a valid semantic_version requirement specification
ERROR! Galaxy import process failed: 'requires_ansible' is not a valid semantic_version requirement specification (Code: None)
```
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
