### PR TITLE
Improve docs validation

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -31,4 +31,4 @@ jobs:
         run: pip install antsibull-docs --disable-pip-version-check
 
       - name: Run collection docs linter
-        run: antsibull-docs lint-collection-docs .
+        run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck


### PR DESCRIPTION
##### SUMMARY
Adding `--plugin-docs` makes `antsibull-docs lint-collection-docs` check the plugin/role/module docs against antsibull-docs's schemas, and also validates the Ansible markup. The validation of the current release is similar to the one of `ansible-test sanity --test validate-modules`, but the next minor release of antsibull-docs will have a better validation.

`--skip-rstcheck` speeds up the linting phase, by not running everything through rstcheck.

##### ISSUE TYPE
- Test Pull Request
- Docs Pull Request

##### COMPONENT NAME
CI
