### PR TITLE
Update CI matrix: 2.12 is EOL, 2.15 is out

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -60,9 +60,10 @@ jobs:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
+          # - stable-2.12 # Only if your collection supports ansible-core 2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
           - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -121,9 +122,10 @@ jobs:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
+          # - stable-2.12 # Only if your collection supports ansible-core 2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
           - devel
         # - milestone
 
@@ -172,43 +174,131 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          # The commented branches below are EOL,
-          # do you really need your collection to support them if it still does?
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
-          # - stable-2.10 # Only if your collection supports ansible-base 2.10
-          # - stable-2.11 # Only if your collection supports ansible-core 2.11
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
           - devel
         # - milestone
         python:
-          - '2.6'
           - '2.7'
-          - '3.5'
           - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
-        exclude:
-          # Because ansible-test doesn't support Python 3.9 for Ansible 2.9
-          # and Python 3.10 is supported in 2.12 or later.
-          - ansible: stable-2.9
-            python: '3.9'
-          - ansible: stable-2.9
-            python: '3.10'
-          - ansible: stable-2.10
-            python: '3.10'
-          - ansible: stable-2.11
-            python: '3.10'
-          # Python 2.6 is not supported with ansible-core >= 2.13
+          - '3.11'
+        include:
+          # Add more CI runs for specific ansible-core + Python combinations
+
+          # The commented branches below are EOL,
+          # do you really need your collection to support them if it still does?
+
+          # Ansible 2.9 - only if your collection supports Ansible 2.9!
+          # - ansible: stable-2.9
+          #   python: '2.6'
+          # - ansible: stable-2.9
+          #   python: '2.7'
+          # - ansible: stable-2.9
+          #   python: '3.5'
+          # - ansible: stable-2.9
+          #   python: '3.6'
+          # - ansible: stable-2.9
+          #   python: '3.7'
+          # - ansible: stable-2.9
+          #   python: '3.8'
+          # ansible-base 2.10 - only if your collection supports ansible 2.10!
+          # - ansible: stable-2.10
+          #   python: '2.6'
+          # - ansible: stable-2.10
+          #   python: '2.7'
+          # - ansible: stable-2.10
+          #   python: '3.5'
+          # - ansible: stable-2.10
+          #   python: '3.6'
+          # - ansible: stable-2.10
+          #   python: '3.7'
+          # - ansible: stable-2.10
+          #   python: '3.8'
+          # - ansible: stable-2.10
+          #   python: '3.9'
+          # ansible-core 2.11 - only if your collection supports ansible 2.11!
+          # - ansible: stable-2.11
+          #   python: '2.6'
+          # - ansible: stable-2.11
+          #   python: '2.7'
+          # - ansible: stable-2.11
+          #   python: '3.5'
+          # - ansible: stable-2.11
+          #   python: '3.6'
+          # - ansible: stable-2.11
+          #   python: '3.7'
+          # - ansible: stable-2.11
+          #   python: '3.8'
+          # - ansible: stable-2.11
+          #   python: '3.9'
+          # ansible-core 2.12 - only if your collection supports ansible 2.12!
+          # - ansible: stable-2.12
+          #   python: '2.6'
+          # - ansible: stable-2.12
+          #   python: '2.7'
+          # - ansible: stable-2.12
+          #   python: '3.5'
+          # - ansible: stable-2.12
+          #   python: '3.6'
+          # - ansible: stable-2.12
+          #   python: '3.7'
+          # - ansible: stable-2.12
+          #   python: '3.8'
+          # - ansible: stable-2.12
+          #   python: '3.9'
+          # - ansible: stable-2.12
+          #   python: '3.10'
+          # ansible-core 2.13
           - ansible: stable-2.13
-            python: '2.6'
+            python: '2.7'
+          - ansible: stable-2.13
+            python: '3.5'
+          - ansible: stable-2.13
+            python: '3.6'
+          - ansible: stable-2.13
+            python: '3.7'
+          - ansible: stable-2.13
+            python: '3.8'
+          - ansible: stable-2.13
+            python: '3.9'
+          - ansible: stable-2.13
+            python: '3.10'
+          # ansible-core 2.14
           - ansible: stable-2.14
-            python: '2.6'
-          - ansible: devel
-            python: '2.6'
+            python: '2.7'
+          - ansible: stable-2.14
+            python: '3.5'
+          - ansible: stable-2.14
+            python: '3.6'
+          - ansible: stable-2.14
+            python: '3.7'
+          - ansible: stable-2.14
+            python: '3.8'
+          - ansible: stable-2.14
+            python: '3.9'
+          - ansible: stable-2.14
+            python: '3.10'
+          - ansible: stable-2.14
+            python: '3.11'
+          # ansible-core 2.15
+          - ansible: stable-2.15
+            python: '2.7'
+          - ansible: stable-2.15
+            python: '3.5'
+          - ansible: stable-2.15
+            python: '3.6'
+          - ansible: stable-2.15
+            python: '3.7'
+          - ansible: stable-2.15
+            python: '3.8'
+          - ansible: stable-2.15
+            python: '3.9'
+          - ansible: stable-2.15
+            python: '3.10'
+          - ansible: stable-2.15
+            python: '3.11'
             
 
     steps:


### PR DESCRIPTION
##### SUMMARY
Also change the integration test matrix to "all versions listed for devel (and maybe latest stable)" + "explicit list of ansible-core + Python versions".

For collections I maintain, I prefer this approach (and I remove a lot of the specific entries to only test a handful Python versions for every ansible-core version).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
