### PR TITLE
ansible-test(.yml): add stable-2.17

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -78,6 +78,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         # - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -137,6 +138,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         # - milestone
 
@@ -249,6 +251,20 @@ jobs:
             python: '3.11'
           - ansible: stable-2.16
             python: '3.12'
+          # ansible-core 2.17
+          - ansible: stable-2.17
+            python: '3.7'
+          - ansible: stable-2.17
+            python: '3.8'
+          - ansible: stable-2.17
+            python: '3.9'
+          - ansible: stable-2.17
+            python: '3.10'
+          - ansible: stable-2.17
+            python: '3.11'
+          - ansible: stable-2.17
+            python: '3.12'
+
 
     steps:
       - name: >-


### PR DESCRIPTION
already branch from devel and release is planned to 20/05/2024

ansible-2.17 drop support of python2.7 and python3.6
