### PR TITLE
Improve changelog config, normalize YAML headers

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,3 +1,4 @@
+---
 # README FIRST
 # 1. Subscribe to https://github.com/ansible-collections/news-for-maintainers
 #    (click the Watch button on the homepage > Custom > Issues)

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -1,3 +1,4 @@
+---
 name: Lint extra docsite docs and links
 on:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+---
 add_plugin_period: true
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+add_plugin_period: true
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
@@ -27,3 +28,4 @@ sections:
   - Known Issues
 title: CHANGE THIS IN changelogs/config.yaml!
 trivial_section_name: trivial
+use_fqcn: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 # CHANGE THIS
 fixes:
    - "/ansible_collections/NAMESPACE/COLLECTION/::"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,3 +1,4 @@
+---
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 
 namespace: community


### PR DESCRIPTION
##### SUMMARY
Improve the changelog config:
1. Use the new feature from antsibull-changelog 0.27.0 that automatically adds periods to new module/plugin descriptions if they don't end with punctuation.
2. Always use FQCNs to announce new plugins/modules.

Also adds the YAML `---` header to every YAML file that isn't auto-generated (i.e. not to changelogs/changelog.yaml).

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
changelog
YAML files
