### PR TITLE
Drop 3.7 from integration test matrix

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -191,7 +191,6 @@ jobs:
           - devel
         # - milestone
         python:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'


### PR DESCRIPTION


##### SUMMARY

Integration tests fail with Python 3.7 and Ansible devel since Python 3.7 is no longer supported (https://github.com/ansible/ansible/pull/82982).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test workflow

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 /home/runner/.local/bin/ansible-test integration -v --color --coverage --retry-on-error --continue-on-error --diff --docker-network=github_network_6fc85d004c82473a8505f3f7fb2f3aa3 --docker default --python 3.7
usage: ansible-test integration [-h] [-e] [-v] [--color [COLOR]] [--debug]
                                [--truncate COLUMNS] [--no-redact]
                                [--include TARGET] [--exclude TARGET]
                                [--require TARGET] [--coverage]
                                [--coverage-check] [--base-branch BRANCH]
                                [--changed] [--untracked] [--ignore-committed]
                                [--ignore-staged] [--ignore-unstaged]
                                [--start-at TARGET] [--start-at-task TASK]
                                [--tags TAGS] [--skip-tags TAGS] [--diff]
                                [--allow-destructive] [--allow-root]
                                [--allow-disabled] [--allow-unstable]
                                [--allow-unstable-changed]
                                [--allow-unsupported] [--retry-on-error]
                                [--continue-on-error] [--debug-strategy]
                                [--changed-all-target TARGET]
                                [--changed-all-mode MODE] [--list-targets]
                                [--no-temp-workdir] [--no-temp-unicode]
                                [--requirements] [--docker-network NET]
                                [--docker-terminate T] [--prime-containers]
                                [--python X.Y] [--python-interpreter PATH]
                                [--local] [--venv]
                                [--venv-system-site-packages]
                                [--docker [IMAGE]] [--docker-privileged]
                                [--docker-seccomp SC] [--docker-memory INT]
                                [--controller OPT] [--target OPT]
                                [TARGET ...]
ansible-test integration: error: argument --python: invalid choice: '3.7' (choose from '3.8', '3.9', '3.10', '3.11', '3.12', 'default')
```
