### PR TITLE
docs/docsite/links.yml: link to the Ansible Forum

### DIFF
--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -46,4 +46,4 @@ communication:
   forums:
     - topic: Ansible Forum
       # The following URL directly points to the "Get Help" section
-      url: https://forum.ansible.com/c/help/6/none
+      url: https://forum.ansible.com/c/help/6

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -43,3 +43,7 @@ communication:
       # You can also add a `subscribe` field with an URI that allows to subscribe
       # to the mailing list. For lists on https://groups.google.com/ a subscribe link is
       # automatically generated.
+  forums:
+    - topic: Ansible Forum
+      # The following URL directly points to the "Get Help" section
+      url: https://forum.ansible.com/c/help/6/none


### PR DESCRIPTION
##### SUMMARY
antsibull-docs has been supporting this since this summer.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/links.yml
