### PR TITLE
ansible-test(.yml): remove stable-2.14

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -76,7 +76,6 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          - stable-2.14
           - stable-2.15
           - stable-2.16
           - stable-2.17
@@ -136,7 +135,6 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          - stable-2.14
           - stable-2.15
           - stable-2.16
           - stable-2.17
@@ -200,23 +198,6 @@ jobs:
           # Add new versions announced in
           # https://github.com/ansible-collections/news-for-maintainers in a timely manner,
           # consider dropping testing against EOL versions and versions you don't support.
-          # ansible-core 2.14
-          - ansible: stable-2.14
-            python: '2.7'
-          - ansible: stable-2.14
-            python: '3.5'
-          - ansible: stable-2.14
-            python: '3.6'
-          - ansible: stable-2.14
-            python: '3.7'
-          - ansible: stable-2.14
-            python: '3.8'
-          - ansible: stable-2.14
-            python: '3.9'
-          - ansible: stable-2.14
-            python: '3.10'
-          - ansible: stable-2.14
-            python: '3.11'
           # ansible-core 2.15
           - ansible: stable-2.15
             python: '2.7'


### PR DESCRIPTION
It is EOL since may 2024 ( https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html )
