### PR TITLE
Improve docs linting workflow

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -26,10 +26,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
-      - name: Install antsibull-docs
-        run: pip install antsibull-docs --disable-pip-version-check
+      - name: Install ansible-core and antsibull-docs
+        run: pip install ansible-core antsibull-docs --disable-pip-version-check
+
+      # OPTIONAL If your collection depends on other collections, make sure to install them here
+      # - name: Install dependent collections
+      #   run: >
+      #     ansible-galaxy collection install
+      #     ansible.netcommon
+      #     ansible.utils
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck


### PR DESCRIPTION
1. Bump Python version from 3.10 to 3.13.
2. Explicitly install ansible-core, to avoid depending on the ansible-core version that happens to be installed in GitHub's base image.
3. Mention that collection dependencies need to be explicitly installed.
