### PR TITLE
Add commented option for codecov token

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -138,6 +138,8 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: units
+          # Uncomment to configure a codecov token
+          # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your unit tests require code
           # from other collections, install them like this
           test-deps: >-
@@ -238,6 +240,8 @@ jobs:
           # pre-test-cmd:
           target-python-version: ${{ matrix.python }}
           testing-type: integration
+          # Uncomment to configure a codecov token
+          # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your integration tests require code
           # from other collections, install them like this
           test-deps: ansible.netcommon

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -97,6 +97,7 @@ jobs:
           testing-type: sanity
           # Uncomment to configure a codecov token.
           # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
+          # Collections in the github.com/ansible-collections/ namespace usually do not need a token.
           # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your sanity tests require code
           # from other collections, install them like this
@@ -143,6 +144,7 @@ jobs:
           testing-type: units
           # Uncomment to configure a codecov token.
           # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
+          # Collections in the github.com/ansible-collections/ namespace usually do not need a token.
           # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your unit tests require code
           # from other collections, install them like this
@@ -246,6 +248,7 @@ jobs:
           testing-type: integration
           # Uncomment to configure a codecov token.
           # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
+          # Collections in the github.com/ansible-collections/ namespace usually do not need a token.
           # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your integration tests require code
           # from other collections, install them like this

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -95,6 +95,9 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
+          # Uncomment to configure a codecov token.
+          # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
+          # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your sanity tests require code
           # from other collections, install them like this
           # test-deps: >-
@@ -138,7 +141,8 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: units
-          # Uncomment to configure a codecov token
+          # Uncomment to configure a codecov token.
+          # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
           # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your unit tests require code
           # from other collections, install them like this
@@ -240,7 +244,8 @@ jobs:
           # pre-test-cmd:
           target-python-version: ${{ matrix.python }}
           testing-type: integration
-          # Uncomment to configure a codecov token
+          # Uncomment to configure a codecov token.
+          # Check here whether a token is required: https://docs.codecov.com/docs/codecov-tokens
           # codecov-token: ${{ secrets.CODECOV_TOKEN }}
           # OPTIONAL If your integration tests require code
           # from other collections, install them like this


### PR DESCRIPTION
##### SUMMARY
This PR adds a commented option for the codecov token.
For me as a first-time github action user, it was quite difficult to figure out that there was a missing option in the ansible-test config.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test github action

