### PR TITLE
Modernize the changelog configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+Will be updated by antsibull-changelog. Do not edit this manually!
+
+See https://ansible.readthedocs.io/projects/antsibull-changelog/changelogs/ for information on how to use antsibull-changelog.
+
+Check out `changelogs/config.yaml` for its configuration. You need to change at least the `title` field in there.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,1 +1,3 @@
+---
+ancestor: null
 releases: {}

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,15 +1,22 @@
 ---
 add_plugin_period: true
-changelog_filename_template: ../CHANGELOG.rst
-changelog_filename_version_depth: 0
+changelog_nice_yaml: true
+changelog_sort: version
 changes_file: changelog.yaml
 changes_format: combined
+ignore_other_fragment_extensions: true
 keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features
 notesdir: fragments
+output:
+- file: CHANGELOG.rst
+  format: rst
+- file: CHANGELOG.md
+  format: md
 prelude_section_name: release_summary
 prelude_section_title: Release Summary
+sanitize_changelog: true
 sections:
 - - major_changes
   - Major Changes
@@ -30,3 +37,4 @@ sections:
 title: CHANGE THIS IN changelogs/config.yaml!
 trivial_section_name: trivial
 use_fqcn: true
+vcs: auto


### PR DESCRIPTION
##### SUMMARY
The example changelog config included in the template drifted from antsibull-changelog's new defaults, and also from new capabilities (like MarkDown output and nicer YAML rendering). I've updated the config to:

- Add MarkDown output;
- Avoid deprecated options;
- Sort versions in correct order;
- Add VCS auto-detection;
- Add nicer YAML rendering.

Inspired by https://github.com/ansible-community/antsibull-changelog/issues/205.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelog config
