### PR TITLE
fix: Documentation URLs to point to `latest` docs pages

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -25,7 +25,7 @@
 #    https://github.com/marketplace/actions/alls-green#gotchas for more detail.
 # 7. If you need help please ask in #community:ansible.com on Matrix
 #    or in bridged #ansible-community on the Libera.Chat IRC channel.
-#    See https://docs.ansible.com/projects/ansible/devel/community/communication.html
+#    See https://docs.ansible.com/projects/ansible/latest/community/communication.html
 #    for details.
 # 8. If your collection is [going to get] included in the Ansible package,
 #    it has to adhere to Python compatibility and CI testing requirements described in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Refer to the [Ansible community guide](https://docs.ansible.com/projects/ansible/devel/community/index.html).
+Refer to the [Ansible community guide](https://docs.ansible.com/projects/ansible/latest/community/index.html).

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ you are encouraged to contribute, share insights, and collaborate with fellow en
 
 ## Code of Conduct
 
-We follow the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.
+We follow the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html) in all our interactions within this project.
 
-If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
+If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
 
 ## Communication
 
@@ -35,40 +35,40 @@ If your collection is not present on the Ansible forum yet, please check out the
   * [Posts tagged with 'your tag'](https://forum.ansible.com/tag/YOUR_TAG): subscribe to participate in collection/technology-related conversations.
   * [Refer to your forum group here if exists](https://forum.ansible.com/g/): by joining the team you will automatically get subscribed to the posts tagged with [your group forum tag here](https://forum.ansible.com/tags).
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/projects/ansible/latest/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
 
-For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/projects/ansible/devel/community/communication.html).
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/projects/ansible/latest/community/communication.html).
 
 ## Contributing to this collection
 
-<!--Describe how the community can contribute to your collection. At a minimum, fill up and include the CONTRIBUTING.md file containing how and where users can create issues to report problems or request features for this collection. List contribution requirements, including preferred workflows and necessary testing, so you can benefit from community PRs. If you are following general Ansible contributor guidelines, you can link to - [Ansible Community Guide](https://docs.ansible.com/projects/ansible/devel/community/index.html). List the current maintainers (contributors with write or higher access to the repository). The following can be included:-->
+<!--Describe how the community can contribute to your collection. At a minimum, fill up and include the CONTRIBUTING.md file containing how and where users can create issues to report problems or request features for this collection. List contribution requirements, including preferred workflows and necessary testing, so you can benefit from community PRs. If you are following general Ansible contributor guidelines, you can link to - [Ansible Community Guide](https://docs.ansible.com/projects/ansible/latest/community/index.html). List the current maintainers (contributors with write or higher access to the repository). The following can be included:-->
 
 The content of this collection is made by people like you, a community of individuals collaborating on making the world better through developing automation software.
 
 We are actively accepting new contributors and all types of contributions are very welcome.
 
-Don't know how to start? Refer to the [Ansible community guide](https://docs.ansible.com/projects/ansible/devel/community/index.html)!
+Don't know how to start? Refer to the [Ansible community guide](https://docs.ansible.com/projects/ansible/latest/community/index.html)!
 
-Want to submit code changes? Take a look at the [Quick-start development guide](https://docs.ansible.com/projects/ansible/devel/community/create_pr_quick_start.html).
+Want to submit code changes? Take a look at the [Quick-start development guide](https://docs.ansible.com/projects/ansible/latest/community/create_pr_quick_start.html).
 
 We also use the following guidelines:
 
-* [Collection review checklist](https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_reviewing.html)
-* [Ansible development guide](https://docs.ansible.com/projects/ansible/devel/dev_guide/index.html)
-* [Ansible collection development guide](https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections)
+* [Collection review checklist](https://docs.ansible.com/projects/ansible/latest/community/collection_contributors/collection_reviewing.html)
+* [Ansible development guide](https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html)
+* [Ansible collection development guide](https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_collections.html#contributing-to-collections)
 
 ## Collection maintenance
 
 The current maintainers are listed in the [MAINTAINERS](MAINTAINERS) file. If you have questions or need help, feel free to mention them in the proposals.
 
-To learn how to maintain/become a maintainer of this collection, refer to the [Maintainer guidelines](https://docs.ansible.com/projects/ansible/devel/community/maintainers.html).
+To learn how to maintain/become a maintainer of this collection, refer to the [Maintainer guidelines](https://docs.ansible.com/projects/ansible/latest/community/maintainers.html).
 
 It is necessary for maintainers of this collection to be subscribed to:
 
 * The collection itself (the `Watch` button -> `All Activity` in the upper right corner of the repository's homepage).
 * The [news-for-maintainers repository](https://github.com/ansible-collections/news-for-maintainers).
 
-They also should be subscribed to Ansible's [The Bullhorn newsletter](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn).
+They also should be subscribed to Ansible's [The Bullhorn newsletter](https://docs.ansible.com/projects/ansible/latest/community/communication.html#the-bullhorn).
 
 ## Governance
 
@@ -122,7 +122,7 @@ You can also install a specific version of the collection, for example, if you n
 ansible-galaxy collection install NAMESPACE.COLLECTION_NAME:==0.1.0
 ```
 
-See [using Ansible collections](https://docs.ansible.com/projects/ansible/devel/user_guide/collections_using.html) for more details.
+See [using Ansible collections](https://docs.ansible.com/projects/ansible/latest/user_guide/collections_using.html) for more details.
 
 ## Release notes
 
@@ -136,11 +136,11 @@ See the [changelog](https://github.com/ansible-collections/REPONAMEHERE/tree/mai
 
 <!-- List out where the user can find additional information, such as working group meeting times, slack/IRC channels, or documentation for the product this collection automates. At a minimum, link to: -->
 
-- [Ansible user guide](https://docs.ansible.com/projects/ansible/devel/user_guide/index.html)
-- [Ansible developer guide](https://docs.ansible.com/projects/ansible/devel/dev_guide/index.html)
-- [Ansible collections requirements](https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_requirements.html)
-- [Ansible community Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html)
-- [The Bullhorn (the Ansible contributor newsletter)](https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn)
+- [Ansible user guide](https://docs.ansible.com/projects/ansible/latest/user_guide/index.html)
+- [Ansible developer guide](https://docs.ansible.com/projects/ansible/latest/dev_guide/index.html)
+- [Ansible collections requirements](https://docs.ansible.com/projects/ansible/latest/community/collection_contributors/collection_requirements.html)
+- [Ansible community Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
+- [The Bullhorn (the Ansible contributor newsletter)](https://docs.ansible.com/projects/ansible/latest/community/communication.html#the-bullhorn)
 - [Important announcements for maintainers](https://github.com/ansible-collections/news-for-maintainers)
 
 ## Licensing

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -1,3 +1,3 @@
 # Review Checklist
 
-Refer to the [Collection review checklist](https://docs.ansible.com/projects/ansible/devel/community/collection_contributors/collection_reviewing.html).
+Refer to the [Collection review checklist](https://docs.ansible.com/projects/ansible/latest/community/collection_contributors/collection_reviewing.html).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,6 +21,6 @@ repository: https://github.com/ansible-collections/community.REPO_NAME
 homepage: https://github.com/ansible-collections/community.REPO_NAME
 issues: https://github.com/ansible-collections/community.REPO_NAME/issues
 build_ignore:
-  # https://docs.ansible.com/projects/ansible/devel/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
+  # https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
   - .gitignore
   - changelogs/.plugin-cache.yaml

--- a/meta/ee-bindep.txt
+++ b/meta/ee-bindep.txt
@@ -5,7 +5,7 @@
 
 # List your controller-side system package requirements here if exist
 # to support easy execution environments building for your collection users
-# https://docs.ansible.com/projects/ansible/devel/getting_started_ee/index.html
+# https://docs.ansible.com/projects/ansible/latest/getting_started_ee/index.html
 # See https://docs.ansible.com/projects/builder/en/latest/collection_metadata/#how-to-verify-collection-level-metadata
 # to learn how to test your configuration.
 # Do not delete this file even if the collection has no dependencies!

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -5,7 +5,7 @@
 
 # List your controller-side Python package requirements here if exist
 # to support easy execution environments building for your collection users
-# https://docs.ansible.com/projects/ansible/devel/getting_started_ee/index.html
+# https://docs.ansible.com/projects/ansible/latest/getting_started_ee/index.html
 # See https://docs.ansible.com/projects/builder/en/latest/collection_metadata/#how-to-verify-collection-level-metadata
 # to learn how to test your configuration.
 # Do not delete this file even if the collection has no dependencies!

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -5,7 +5,7 @@
 
 # List your controller-side system package and/or Python package requirements
 # if exist in the files specified below to support easy execution environments building for your collection users
-# https://docs.ansible.com/projects/ansible/devel/getting_started_ee/index.html
+# https://docs.ansible.com/projects/ansible/latest/getting_started_ee/index.html
 # See https://docs.ansible.com/projects/builder/en/latest/collection_metadata/#how-to-verify-collection-level-metadata
 # to learn how to test your configuration.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Changes documentation URLs from `devel` to point to `latest`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
