### PR TITLE
README.md: add reference to Ansible community AI policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ We follow the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansibl
 
 If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
 
+## AI Policy
+
+We follow the [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html) when contributing to this project.
+
 ## Communication
 
 <!--

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you encounter abusive behavior, please refer to the [policy violations](https
 
 ## AI Policy
 
-We follow the [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html) when contributing to this project.
+This project follows the [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html).
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,12 @@ We welcome members from all skill levels to participate actively in our open, in
 Whether you are an expert or just beginning your journey with Ansible and `your collection name`,
 you are encouraged to contribute, share insights, and collaborate with fellow enthusiasts!
 
-## Code of Conduct
+## Community standards
 
-We follow the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all our interactions within this project.
+This project follows:
 
-If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
-
-## AI Policy
-
-This project follows the [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html).
+* The [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all our interactions within this project. If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
+* The [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html).
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ you are encouraged to contribute, share insights, and collaborate with fellow en
 
 This project follows:
 
-* The [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all our interactions within this project. If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
+* The [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all interactions within this project. If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
 * The [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html).
 
 ## Communication

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ you are encouraged to contribute, share insights, and collaborate with fellow en
 
 ## Community standards
 
-This project follows:
+This project abides by the following policies:
 
-* The [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html) in all interactions within this project. If you encounter abusive behavior, please refer to the [policy violations](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html#policy-violations) section of the Code for information on how to raise a complaint.
-* The [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html).
+* [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/devel/community/code_of_conduct.html)
+* [Ansible Community Policy for AI-Assisted Contributions](https://docs.ansible.com/projects/ansible/devel/community/ai_policy.html)
 
 ## Communication
 


### PR DESCRIPTION
##### SUMMARY
docs(README.md): add reference to Ansible community AI policy